### PR TITLE
remove unknown method

### DIFF
--- a/lib/iban_client/errors.rb
+++ b/lib/iban_client/errors.rb
@@ -16,7 +16,6 @@ module IbanClient
     end
 
     def message
-      "#{initial_error.message}\n"\
       "Request iban: #{iban}\n"\
       "Response: #{response}"
     end

--- a/spec/lib/errors_spec.rb
+++ b/spec/lib/errors_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe IbanClient::RequestError do
+  subject(:request_error) { described_class.new(iban: nil, response: nil) }
+
+  describe 'message' do
+    subject(:message) { request_error.message }
+
+    it 'does not raise' do
+      expect { message }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
Isssue: 
`NameError: undefined local variable or method` `initial_error` for `#<IbanClient::RequestError: IbanClient::RequestError>`

This pull request will remove calls to this method  and add a test suite for the `message` method in `IbanClient::RequestError`