### PR TITLE
Always return request error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    iban_client (0.0.6)
+    iban_client (0.0.7)
       rest-client (~> 2.0)
 
 GEM

--- a/lib/iban_client/iban.rb
+++ b/lib/iban_client/iban.rb
@@ -53,6 +53,8 @@ module IbanClient
       )
     rescue RestClient::ExceptionWithResponse => err
       raise IbanClient::RequestError.new(iban: iban, response: err.response)
+    rescue => err
+      raise IbanClient::RequestError.new(iban: iban, response: err.message)
     end
 
     def params

--- a/lib/iban_client/version.rb
+++ b/lib/iban_client/version.rb
@@ -1,3 +1,3 @@
 module IbanClient
-  VERSION = '0.0.6'
+  VERSION = '0.0.7'
 end

--- a/spec/lib/iban_client/iban_spec.rb
+++ b/spec/lib/iban_client/iban_spec.rb
@@ -62,9 +62,7 @@ describe IbanClient::Iban, iban: true do
       before do
         allow(RestClient::Request).to receive(:execute).and_raise(StandardError, "Cant connect")
       end
-      it { expect { subject.bic }.to raise_error(IbanClient::RequestError) do |error|
-        expect(error).to have_attributes(response: "Cant connect")
-      end }
+      it { expect { subject.bic }.to raise_error(IbanClient::RequestError, /Response: Cant connect/) }
     end
   end
 

--- a/spec/lib/iban_client/iban_spec.rb
+++ b/spec/lib/iban_client/iban_spec.rb
@@ -57,6 +57,15 @@ describe IbanClient::Iban, iban: true do
       let(:iban) { 'invalid_json' }
       it { expect { subject.bic }.to raise_error(IbanClient::RequestError) }
     end
+
+    context 'with an unexpected error' do
+      before do
+      allow(RestClient::Request).to receive(:execute).and_raise(StandardError, "Cant connect")
+      end
+      it { expect { subject.bic }.to raise_error(IbanClient::RequestError) do |error|
+        expect(error).to have_attributes(response: "Cant connect")
+      end }
+    end
   end
 
   describe 'sepa_data' do

--- a/spec/lib/iban_client/iban_spec.rb
+++ b/spec/lib/iban_client/iban_spec.rb
@@ -60,7 +60,7 @@ describe IbanClient::Iban, iban: true do
 
     context 'with an unexpected error' do
       before do
-      allow(RestClient::Request).to receive(:execute).and_raise(StandardError, "Cant connect")
+        allow(RestClient::Request).to receive(:execute).and_raise(StandardError, "Cant connect")
       end
       it { expect { subject.bic }.to raise_error(IbanClient::RequestError) do |error|
         expect(error).to have_attributes(response: "Cant connect")


### PR DESCRIPTION
## Why
During an iban.com unavailability, the iban-client raised errors with different types than the expected IbanClient::RequestError. This led to returning 500 to the client and piling up dead jobs without retries. This MR aims to make the iban client return only one kind of error so they can be more easily handled.

## How
Make the iban-client always return a IbanClient::RequestError in case of error when requesting iban.com

## Resource
[Counter measure](https://www.notion.so/qonto/Make-sure-we-gracefully-handle-exceptions-received-from-the-iban-client-9901f701d4b4442abc7ef3093b83ff6f)